### PR TITLE
fix: [Solved] cannot retrieve data with provider network

### DIFF
--- a/lib/api/api_authentication.dart
+++ b/lib/api/api_authentication.dart
@@ -110,8 +110,16 @@ class UserAPI {
         responseString = 'Please check your internet connection!';
         return;
       }
-      http.Response resp =
-          await http.get(dashboardURL, headers: {'Cookie': cookie});
+
+      if (cookie.contains(",") == true) {
+        var temp = cookie.split(',');
+        cookie = temp[1];
+      }
+
+      http.Response resp = await http.get(dashboardURL, headers: {
+        'Cookie': cookie,
+      });
+
 
       if (resp.statusCode != 200) {
         responseString = 'Try again!';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = MyHttpOverrides();
   DB();
   await AwesomeNotifications().initialize(
     // set the 'default' icon for notifications


### PR DESCRIPTION
idk but the UNAI server gives 2 joined cookies when connecting with provider conn which caused the app must be back to the login page. So I split up the joined cookie and choose the last (valid one).  